### PR TITLE
rename CrayIMKL in crayimkl.py to CrayIntelMKL in crayintelmkl.py to match CrayIntelMKL toolchain name + bump copyright

### DIFF
--- a/easybuild/toolchains/crayintelmkl.py
+++ b/easybuild/toolchains/crayintelmkl.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2014-2019 Ghent University
+# Copyright 2014-2020 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
@@ -35,7 +35,7 @@ from easybuild.toolchains.mpi.craympich import CrayMPICH
 from easybuild.tools.toolchain.toolchain import SYSTEM_TOOLCHAIN_NAME
 
 
-class CrayIMKL(CrayPEIntel, CrayMPICH, CrayMKL):
+class CrayIntelMKL(CrayPEIntel, CrayMPICH, CrayMKL):
     """Compiler toolchain for Cray Programming Environment for Intel compilers and MKL (PrgEnv-intel)."""
     NAME = 'CrayIntelMKL'
     SUBTOOLCHAIN = SYSTEM_TOOLCHAIN_NAME

--- a/easybuild/toolchains/linalg/craymkl.py
+++ b/easybuild/toolchains/linalg/craymkl.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2014-2019 Ghent University
+# Copyright 2014-2020 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),


### PR DESCRIPTION
@gppezzi for https://github.com/easybuilders/easybuild-framework/pull/3156

We should also add an `HPL` easyconfig using `CrayIntelMKL` as a toolchain (like we have for the other existing `Cray*` toolchains)?